### PR TITLE
Update to docker-compose.yml, added helloworld endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,4 @@ services:
       - ./game:/game
     working_dir: /game
     ports:
-      - "9001:9001"
+      - "9001:9017"

--- a/game/app.py
+++ b/game/app.py
@@ -65,6 +65,9 @@ class ExtendedFlaskMessageLaunch(FlaskMessageLaunch):
 def get_lti_config_path():
     return os.path.join(app.root_path, '..', 'configs', 'game.json')
 
+@app.route('/helloworld/', methods=['GET'])
+def hello_world():
+    return('<h1>Hello World</h1>')
 
 @app.route('/check-cookies-allowed/', methods=['GET'])
 def check_cookies_allowed():


### PR DESCRIPTION
Testing with Docker deploy and Blackboard Learn. The [docker-compose.yml](https://github.com/dmitry-viskov/pylti1.3-flask-example/compare/master...shurrey:master?expand=1#diff-4e5e90c6228fd48698d074241c2ba760) forwards host port 9001 to container port 9001, but in app.py, we tell Flask to start on 9017. 

Also, to test locally that docker is running, I added a simple /helloworld/ endpoint to verify that its running.