### PR TITLE
return keys directly instead of keys object

### DIFF
--- a/game/app.py
+++ b/game/app.py
@@ -127,7 +127,7 @@ def launch():
 @app.route('/jwks/', methods=['GET'])
 def get_jwks():
     tool_conf = ToolConfJsonFile(get_lti_config_path())
-    return jsonify({'keys': tool_conf.get_jwks()})
+    return jsonify(tool_conf.get_jwks())
 
 
 @app.route('/configure/<launch_id>/<difficulty>/', methods=['GET', 'POST'])


### PR DESCRIPTION
This change helped me to get this example project to work with Moodle.

Without this change the score-related API calls did not work. However if I undo the change they still work, so I think maybe Moodle remembered the keys once and that prevents the issue from triggering now.

I suspect triggering the bug and then confirming the fix might require a fresh Moodle instance.

Without this change I get somehting like

```
Exception - Argument 1 passed to Firebase\\JWT\\JWK::parseKeySet() must be of the type array, null given
```